### PR TITLE
[feat] 添加 GsonSerializer 支持

### DIFF
--- a/xxl-cache-core/src/main/java/com/xxl/cache/core/factory/XxlCacheFactory.java
+++ b/xxl-cache-core/src/main/java/com/xxl/cache/core/factory/XxlCacheFactory.java
@@ -174,7 +174,7 @@ public class XxlCacheFactory {
             public void onMessage(byte[] channel, byte[] message) {
 
                 // deserialize message
-                CacheBroadcastMessage broadcastMessage = SerializerTypeEnum.JAVA.getSerializer().deserialize(message);
+                CacheBroadcastMessage broadcastMessage = l2CacheManager.getSerializer().deserialize(message, CacheBroadcastMessage.class);
 
                 // refresh by key
                 String finalKey = CacheUtil.generateKey(broadcastMessage.getCategory(), broadcastMessage.getKey());

--- a/xxl-cache-core/src/main/java/com/xxl/cache/core/redis/RedisCache.java
+++ b/xxl-cache-core/src/main/java/com/xxl/cache/core/redis/RedisCache.java
@@ -3,7 +3,6 @@ package com.xxl.cache.core.redis;
 import com.xxl.cache.core.cache.Cache;
 import com.xxl.cache.core.cache.CacheValue;
 import com.xxl.cache.core.serialize.Serializer;
-import com.xxl.cache.core.serialize.SerializerTypeEnum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.*;
@@ -63,7 +62,7 @@ public class RedisCache implements Cache {
                     return null;
                 }
 
-                return serializer.deserialize(valueBytes);
+                return serializer.deserialize(valueBytes, CacheValue.class);
             } catch (Exception e) {
                 logger.error(e.getMessage(), e);
             }
@@ -74,7 +73,7 @@ public class RedisCache implements Cache {
                     return null;
                 }
 
-                return serializer.deserialize(valueBytes);
+                return serializer.deserialize(valueBytes, CacheValue.class);
             } catch (Exception e) {
                 logger.error(e.getMessage(), e);
             }
@@ -137,7 +136,7 @@ public class RedisCache implements Cache {
      */
     public void publish(String channel, Object message) {
         // serialize message
-        byte[] messageBytes = SerializerTypeEnum.JAVA.getSerializer().serialize(message);
+        byte[] messageBytes = this.serializer.serialize(message);
 
         // invoke
         if (jedisCluster!=null) {

--- a/xxl-cache-core/src/main/java/com/xxl/cache/core/redis/RedisManager.java
+++ b/xxl-cache-core/src/main/java/com/xxl/cache/core/redis/RedisManager.java
@@ -141,4 +141,10 @@ public class RedisManager {
         return defaultRedisCache;
     }
 
+
+    // ---------------------- getter/setter ----------------------
+
+    public Serializer getSerializer() {
+        return serializer;
+    }
 }

--- a/xxl-cache-core/src/main/java/com/xxl/cache/core/serialize/Serializer.java
+++ b/xxl-cache-core/src/main/java/com/xxl/cache/core/serialize/Serializer.java
@@ -20,9 +20,10 @@ public abstract class Serializer {
 	 * deserialize
 	 *
 	 * @param bytes
+	 * @param clazz
 	 * @return
 	 * @param <T>
 	 */
-	public abstract <T> T deserialize(byte[] bytes);
+	public abstract <T> T deserialize(byte[] bytes, Class<T> clazz);
 
 }

--- a/xxl-cache-core/src/main/java/com/xxl/cache/core/serialize/SerializerTypeEnum.java
+++ b/xxl-cache-core/src/main/java/com/xxl/cache/core/serialize/SerializerTypeEnum.java
@@ -1,5 +1,6 @@
 package com.xxl.cache.core.serialize;
 
+import com.xxl.cache.core.serialize.impl.GsonSerializer;
 import com.xxl.cache.core.serialize.impl.JavaSerializer;
 
 /**
@@ -9,7 +10,8 @@ import com.xxl.cache.core.serialize.impl.JavaSerializer;
  */
 public enum SerializerTypeEnum {
 
-    JAVA("java", new JavaSerializer());
+    JAVA("java", new JavaSerializer()),
+    GSON("gson", new GsonSerializer());
 
     private String type;
     private Serializer serializer;

--- a/xxl-cache-core/src/main/java/com/xxl/cache/core/serialize/impl/GsonSerializer.java
+++ b/xxl-cache-core/src/main/java/com/xxl/cache/core/serialize/impl/GsonSerializer.java
@@ -1,33 +1,28 @@
 package com.xxl.cache.core.serialize.impl;
 
+import com.google.gson.Gson;
 import com.xxl.cache.core.serialize.Serializer;
 
-import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 /**
- * serializer
+ * GsonSerializer
  *
- * @author xuxueli 2025-02-07
+ * @author aruato 2025-08-27
  */
-public class JavaSerializer extends Serializer {
+public class GsonSerializer extends Serializer {
 
-    /**
-     * serialize
-     *
-     * @param obj
-     * @return
-     * @param <T>
-     */
+    private static final Gson GSON = new Gson();
+
     @Override
     public <T> byte[] serialize(T obj) {
         if (obj == null) {
             throw new RuntimeException("Cannot serialize null object");
         }
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-            oos.writeObject(obj);
-            return baos.toByteArray();
-        } catch (IOException e) {
+        try {
+            String json = GSON.toJson(obj);
+            return json.getBytes(StandardCharsets.UTF_8);
+        } catch (Exception e) {
             throw new RuntimeException("Failed to serialize object: " + e.getMessage(), e);
         }
     }
@@ -37,9 +32,9 @@ public class JavaSerializer extends Serializer {
         if (bytes == null) {
             throw new RuntimeException("Cannot deserialize null byte array");
         }
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-             ObjectInputStream ois = new ObjectInputStream(bais)) {
-            return (T) ois.readObject();
+        try {
+            String json = new String(bytes, StandardCharsets.UTF_8);
+            return (T) GSON.fromJson(json, clazz);
         } catch (Exception e) {
             throw new RuntimeException("Failed to deserialize object: " + e.getMessage(), e);
         }

--- a/xxl-cache-core/src/test/java/com/xxl/cache/core/test/factory/XxlCacheHelperTest.java
+++ b/xxl-cache-core/src/test/java/com/xxl/cache/core/test/factory/XxlCacheHelperTest.java
@@ -3,6 +3,7 @@ package com.xxl.cache.core.test.factory;
 import com.xxl.cache.core.XxlCacheHelper;
 import com.xxl.cache.core.cache.CacheTypeEnum;
 import com.xxl.cache.core.factory.XxlCacheFactory;
+import com.xxl.cache.core.serialize.SerializerTypeEnum;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -18,6 +19,50 @@ public class XxlCacheHelperTest {
         XxlCacheFactory xxlCacheFactory = new XxlCacheFactory();
         xxlCacheFactory.setL1Provider(CacheTypeEnum.CAFFEINE.getType());
         xxlCacheFactory.setL2Provider(CacheTypeEnum.REDIS.getType());
+        xxlCacheFactory.setNodes("127.0.0.1:6379");
+        xxlCacheFactory.setPassword(null);
+
+        xxlCacheFactory.start();
+
+        // test
+        String category = "user";
+        String key = "user03";
+
+        XxlCacheHelper.XxlCache xxlCache = XxlCacheHelper.getCache(category);
+
+        // 先清除，避免 Redis 有缓存，影响测试
+        xxlCache.del(key);
+        // 写操作对应：本地 L1 写 --> L2 写 --> 广播消息 --> 本地节点收到消息，再写一次 L1
+        TimeUnit.SECONDS.sleep(3);
+
+        String val = xxlCache.get(key);
+        assertNull(val);
+
+        xxlCache.set(key, "jack333");
+        TimeUnit.SECONDS.sleep(3);
+
+        // 存换操作后，比对
+        val = xxlCache.get(key);
+        assertEquals("jack333", val);
+
+        // 清理
+        xxlCache.del(key);
+        TimeUnit.SECONDS.sleep(3);
+
+        val = xxlCache.get(key);
+        assertNull(val);
+
+        // stop
+        xxlCacheFactory.stop();
+    }
+
+    @Test
+    public void testXxlCacheHelperCRUDWithGson() throws InterruptedException {
+        // start
+        XxlCacheFactory xxlCacheFactory = new XxlCacheFactory();
+        xxlCacheFactory.setL1Provider(CacheTypeEnum.CAFFEINE.getType());
+        xxlCacheFactory.setL2Provider(CacheTypeEnum.REDIS.getType());
+        xxlCacheFactory.setSerializer(SerializerTypeEnum.GSON.getType());
         xxlCacheFactory.setNodes("127.0.0.1:6379");
         xxlCacheFactory.setPassword(null);
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [√ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
1. Redis添加了gson序列化的支持（jedis自带gson包），支持按照配置（xxl.cache.l2.serializer=gson）动态切换。
2. 发布/订阅消息的序列化方式和Redis Value保持一致，同样支持按照配置（xxl.cache.l2.serializer=gson）动态切换。之前对于发布/订阅消息的序列化都是固定使用的Java原生的序列化，性能较差，序列化后的字节数也较大。


**Other information:**
目前为了不引入额外的maven依赖，所以只做了gson，如果需要的话，jackson等也可以添加进去